### PR TITLE
Updates to use v1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@angular/common": "^6.0.0-rc.0 || ^6.0.0",
     "@angular/core": "^6.0.0-rc.0 || ^6.0.0",
     "@angular/forms": "^6.0.0-rc.0 || ^6.0.0",
-    "tributejs": "git://github.com/rcavezza/tribute"
+    "tributejs": "github:rcavezza/tribute#v1.0"
   },
   "description": "Angular 2+ wrapper for Zurb's Tribute.js library for native @mentions",
   "repository": {


### PR DESCRIPTION
Changes `ngx-tribute` to use v1 from our fork of tributejs